### PR TITLE
Upgrade gems

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,18 +1,17 @@
 GEM
   remote: http://rubygems.org/
   specs:
-    activemodel (5.2.3)
-      activesupport (= 5.2.3)
-    activerecord (5.2.3)
-      activemodel (= 5.2.3)
-      activesupport (= 5.2.3)
-      arel (>= 9.0)
-    activesupport (5.2.3)
+    activemodel (6.0.0)
+      activesupport (= 6.0.0)
+    activerecord (6.0.0)
+      activemodel (= 6.0.0)
+      activesupport (= 6.0.0)
+    activesupport (6.0.0)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
-    arel (9.0.0)
+      zeitwerk (~> 2.1, >= 2.1.8)
     backports (3.15.0)
     builder (3.2.3)
     coderay (1.1.2)
@@ -62,6 +61,7 @@ GEM
     tilt (2.0.9)
     tzinfo (1.2.5)
       thread_safe (~> 0.1)
+    zeitwerk (2.1.9)
 
 PLATFORMS
   ruby

--- a/gemset.nix
+++ b/gemset.nix
@@ -5,40 +5,32 @@
     platforms = [];
     source = {
       remotes = ["http://rubygems.org"];
-      sha256 = "0mghh9di8011ara9h1r5a216yzk1vjm9r3p0gdvdi8j1zmkl6k6h";
+      sha256 = "1jr7s47vblpi89yvba5c7zpkqyzzc2p0qw78wqli4aj9yniykgsc";
       type = "gem";
     };
-    version = "5.2.3";
+    version = "6.0.0";
   };
   activerecord = {
-    dependencies = ["activemodel" "activesupport" "arel"];
+    dependencies = ["activemodel" "activesupport"];
     groups = ["default"];
     platforms = [];
     source = {
       remotes = ["http://rubygems.org"];
-      sha256 = "0d6036f592803iyvp6bw98p3sg638mia5dbw19lvachx6jgzfvpw";
+      sha256 = "00v3di3krpj8x2c1ww3s2bg3szdmcfix3dhrnan5fz2kpdviili6";
       type = "gem";
     };
-    version = "5.2.3";
+    version = "6.0.0";
   };
   activesupport = {
-    dependencies = ["concurrent-ruby" "i18n" "minitest" "tzinfo"];
+    dependencies = ["concurrent-ruby" "i18n" "minitest" "tzinfo" "zeitwerk"];
     groups = ["default"];
     platforms = [];
     source = {
       remotes = ["http://rubygems.org"];
-      sha256 = "110vp4frgkw3mpzlmshg2f2ig09cknls2w68ym1r1s39d01v0mi8";
+      sha256 = "0b24ch7zmrdb4h6aismahk9785lc4ij30lmdr6ydv19kkljsjq5v";
       type = "gem";
     };
-    version = "5.2.3";
-  };
-  arel = {
-    source = {
-      remotes = ["http://rubygems.org"];
-      sha256 = "1jk7wlmkr61f6g36w9s2sn46nmdg6wn2jfssrhbhirv5x9n95nk0";
-      type = "gem";
-    };
-    version = "9.0.0";
+    version = "6.0.0";
   };
   backports = {
     groups = ["default"];
@@ -306,5 +298,15 @@
       type = "gem";
     };
     version = "1.2.5";
+  };
+  zeitwerk = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["http://rubygems.org"];
+      sha256 = "0gaiqg207j99cvqpgmn4ps6a14hz1rrh5zaxfdkiiavapbc5vpzw";
+      type = "gem";
+    };
+    version = "2.1.9";
   };
 }


### PR DESCRIPTION
[Rails 6](.org/2019/8/15/Rails-6-0-final-release/) was recently released. While we don't use Rails, we use Sinatra, we're still using some pieces of Rails such as [ActiveModel](https://github.com/rails/rails/blob/v6.0.0/activemodel/CHANGELOG.md), [ActiveSupport](https://github.com/rails/rails/blob/v6.0.0/activesupport/CHANGELOG.md), and [ActiveRecord](https://github.com/rails/rails/blob/v6.0.0/activerecord/CHANGELOG.md).

This PR upgrades the aforementioned gems to `v6.0.0` and adds [Zeitwerk](https://github.com/fxn/zeitwerk), the new standard Ruby code loader gem. So fresh, so clean, so up to date.