### PR TITLE
Add Dependabot

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -1,0 +1,14 @@
+version: 1
+update_configs:
+  - package_manager: "ruby:bundler"
+    directory: "/"
+    update_schedule: "weekly"
+
+    # Apply default reviewer and label to created
+    # pull requests
+    default_reviewers:
+      - larouxn
+    default_labels:
+      - "gem upgrades"
+
+    version_requirement_updates: "auto"


### PR DESCRIPTION
While we'll still have to manually bump the `gemset.nix` versions, adding [Dependabot](https://dependabot.com/) will automatically create gem bump PRs for us and thus ensure we're at least aware of the the potential upgrades. Dependabot is a great tool. We use it at Shopify and I have it set up in a [personal project](https://github.com/larouxn/carrotgram/blob/9eb6fdb88770ce80aa886484f03eed3d50043f71/.dependabot/config.yml) as well.

Up until now, I've just been manually running `bundle --outdated` locally to check.