### PR TITLE
Clean up Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,16 +1,16 @@
 source 'http://rubygems.org'
 
-gem 'sinatra', '~>2.0'
-gem 'sinatra-contrib', '~>2.0'
-gem 'sinatra-activerecord', '~>2.0'
-gem 'puma', '~>4.0'
-gem 'rake', '~>12.3'
-gem 'builder', '~>3.2'
-gem 'nokogiri', '~>1.10'
-gem 'pony', '~>1.0'
+gem 'sinatra'
+gem 'sinatra-contrib'
+gem 'sinatra-activerecord'
+gem 'puma'
+gem 'rake'
+gem 'builder'
+gem 'nokogiri'
+gem 'pony'
 
 group :development do
-  gem 'sqlite3', '~>1.4'
+  gem 'sqlite3'
   gem 'pry'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -24,7 +24,7 @@ GEM
     mini_mime (1.0.2)
     mini_portile2 (2.4.0)
     minitest (5.12.2)
-    multi_json (1.14.0)
+    multi_json (1.14.1)
     mustermann (1.0.3)
     nio4r (2.5.2)
     nokogiri (1.10.4)
@@ -40,7 +40,7 @@ GEM
     rack (2.0.7)
     rack-protection (2.0.7)
       rack
-    rake (12.3.3)
+    rake (13.0.0)
     sinatra (2.0.7)
       mustermann (~> 1.0)
       rack (~> 2.0)
@@ -67,17 +67,17 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  builder (~> 3.2)
-  nokogiri (~> 1.10)
+  builder
+  nokogiri
   pg (~> 0.21)
-  pony (~> 1.0)
+  pony
   pry
-  puma (~> 4.0)
-  rake (~> 12.3)
-  sinatra (~> 2.0)
-  sinatra-activerecord (~> 2.0)
-  sinatra-contrib (~> 2.0)
-  sqlite3 (~> 1.4)
+  puma
+  rake
+  sinatra
+  sinatra-activerecord
+  sinatra-contrib
+  sqlite3
 
 BUNDLED WITH
    1.17.2

--- a/gemset.nix
+++ b/gemset.nix
@@ -131,10 +131,10 @@
     platforms = [];
     source = {
       remotes = ["http://rubygems.org"];
-      sha256 = "1gysslvn8zvnn0jn3nb60zsci962vxdri4w6ilki5mi2jwy24bgi";
+      sha256 = "0xy54mjf7xg41l8qrg1bqri75agdqmxap9z466fjismc1rn2jwfr";
       type = "gem";
     };
-    version = "1.14.0";
+    version = "1.14.1";
   };
   mustermann = {
     source = {
@@ -230,10 +230,10 @@
     platforms = [];
     source = {
       remotes = ["http://rubygems.org"];
-      sha256 = "1cvaqarr1m84mhc006g3l1vw7sa5qpkcw0138lsxlf769zdllsgp";
+      sha256 = "05l80mgaabdipkjsnjlffn9gc1wx9fi629d2kfbz8628cx3m6686";
       type = "gem";
     };
-    version = "12.3.3";
+    version = "13.0.0";
   };
   sinatra = {
     dependencies = ["mustermann" "rack" "rack-protection" "tilt"];


### PR DESCRIPTION
Realized we unnecessarily haver versions specified for many gems. Only one we need to keep locked down is `pg` as we're back a major version on that. Everything else can relax.