### PR TITLE
Add startup script

### DIFF
--- a/start
+++ b/start
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+source /home/deploy/.bash_profile
+cd /home/deploy/mmp
+pumactl start


### PR DESCRIPTION
This adds a simple bash script that can be run on boot for the `deploy` user via `crontab`.

`crontab -e` configuration ([research](https://kvz.io/schedule-tasks-on-linux-using-crontab.html)):
```
@reboot /home/deploy/mmp/start >> /home/deploy/mmp/var/log/start_script_output.log 2>&1
```

I have tested this script + rebooting staging. The application automatically starts after a reboot. 👍 

---

This will also unblock us from enabling automatic reboots for automatic reboots via the config in `/etc/apt/apt.conf.d/50unattended-upgrades`. ([research](https://libre-software.net/ubuntu-automatic-updates/))