### PR TITLE
[Travis] bundle exec pumactl

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,14 +29,14 @@ deploy:
       bundle install;
       rm -rf public;
       mv ../public .;
-      if [ -f var/run/puma.pid ]; then pumactl stop; fi;
+      if [ -f var/run/puma.pid ]; then bundle exec pumactl stop; fi;
       if [ -S /tmp/puma.sock ]; then rm /tmp/puma.sock; fi;
       '" &&
     ssh "$user@$staging" '
       set -e;
       . /home/$user/.rvm/scripts/rvm;
       cd mmp;
-      pumactl start > /tmp/puma-start 2>&1 &
+      bundle exec pumactl start > /tmp/puma-start 2>&1 &
       sleep 30;
       grep -C 10 "Daemonizing" /tmp/puma-start;
       ';


### PR DESCRIPTION
Ruby 2.7.0 seems to lack whatever shortcutting allowed for the automagical presence of bundle context when executing gem commands such as `pumactl`. This PR updates our Travis CI config deploy script to explicitly execute `pumactl` within bundle context via `bundle exec pumactl`.

This should allow us to use Ruby 2.7.0, which will release tomorrow on Christmas. 🎄 