### PR TITLE
Update bundler to v2.1.4

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -80,4 +80,4 @@ DEPENDENCIES
   sqlite3
 
 BUNDLED WITH
-   1.17.2
+   2.1.4


### PR DESCRIPTION
I don't quite recall why we locked Bundle to v1.17.2 but that's from December 2018. We can/should probably use a fresher version. :)

![bundler](https://user-images.githubusercontent.com/1557529/72664517-31719000-3a42-11ea-9aab-f6d0f6c7b541.png)

```
/nix/store/lcabxws0khz10wz0614pxqz67fjhkm78-ruby-2.5.3/lib/ruby/2.5.0/rubygems/dependency.rb:312:in `to_specs': Could not find 'bundler' (2.1.4) required by your /home/travis/build/robwhitaker/mmp-website/Gemfile.lock. (Gem::MissingSpecVersionError)
```

Seems `gem install bundler; bundle update --bundler` could resolve this.

---

But then the build passed anyway. 🤷‍♂️
<img width="451" alt="Screen Shot 2020-01-18 at 22 44 24" src="https://user-images.githubusercontent.com/1557529/72664695-2ae41800-3a44-11ea-8933-88661e30fae4.png">